### PR TITLE
Attempt to detect the correct processor type under Snow Leopard's gdb.

### DIFF
--- a/.gdb/detect-target.sh
+++ b/.gdb/detect-target.sh
@@ -5,6 +5,9 @@ TARGET_DOUBLET=$(grep 'file type' /tmp/gdb_info_target |
                  cut -d ' ' -f 4 |
                  uniq |
                  tr -d '\n')
+OSABI=$(grep 'currently ' /tmp/gdb_info_target |
+        sed 's/.*currently "\([^"]*\)".*/\1/' |
+        tr -d '\n')
 GDB_FILE="/tmp/gdb_target_arch.gdb"
 rm -f "$GDB_FILE"
 
@@ -22,5 +25,13 @@ case "$TARGET_DOUBLET" in
     *-*mips*)
         echo "set \$MIPS = 1" >> $GDB_FILE;
         echo "set \$64BITS = 1" >> $GDB_FILE;
+        ;;
+    mach-o-*)
+        if test "$OSABI" == "Darwin64"; then
+            echo "set \$X86_64 = 1" >> $GDB_FILE;
+            echo "set \$64BITS = 1" >> $GDB_FILE;
+        elif test "$OSABI" == "Darwin"; then
+            echo "set \$X86 = 1" >> $GDB_FILE;
+        fi
         ;;
 esac

--- a/.gdb/setup.gdb
+++ b/.gdb/setup.gdb
@@ -12,6 +12,7 @@ define setup-detect-target
   set logging on
   set pagination off
   info target
+  show osabi
   set pagination on
   set logging off
   set logging redirect off


### PR DESCRIPTION
Unfortunately, gdb under Snow Leopard doesn't give a useful doublet.  So
let's go the extra step and grab the osabi and use it to determine what
processor we're using and the size.
