### PR TITLE
Allow user to override config options

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -46,6 +46,10 @@ set $CONTEXTSIZE_STACK = 6
 set $CONTEXTSIZE_DATA  = 8
 set $CONTEXTSIZE_CODE  = 8
 
+# Override configuration options defined above for the local machine. This file
+# should never go into version control.
+source ~/.gdbinit.local-pre
+
 # Options
 ###
 


### PR DESCRIPTION
The .gdbinit.local file is included too late in the .gdbinit to change some options (ex: $COLOUREDPROMPT). Allow the user to specify a local-pre file that can override those options before they're evaluated.
